### PR TITLE
Refactor export history and 3D viewer UI for mobile

### DIFF
--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -18,13 +18,11 @@ import {
   Wand2,
   X,
   Sparkles,
-  History, // Mengganti ViewInAr yang error
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 import { toast, Toaster } from "sonner";
 
-// Import komponen-komponen studio
 import { GeneratorForm } from "@/components/studio/generator-form";
 import { ImageUploadForm } from "@/components/studio/image-upload-form";
 import { ResultsDisplay } from "@/components/studio/results-display";
@@ -37,7 +35,6 @@ import { ExportHistory } from "@/components/studio/export-history";
 import { ExportProgress } from "@/components/studio/export-progress";
 import { Wastra3DViewer } from "@/components/studio/wastra-3d-viewer";
 
-// Import utilities & types
 import { exportHistory } from "@/lib/export-history";
 import type {
   RapportSize,
@@ -45,11 +42,6 @@ import type {
   ExportResponse,
 } from "@/app/types/export";
 
-// =========================================================
-// FIX: MODULE AUGMENTATION UNTUK MENGATASI PROP ERRORS (TS2322)
-// =========================================================
-
-// 1. Tambahkan props custom ke ExportDialog
 declare module "@/components/studio/export-dialog" {
   export interface ExportDialogProps {
     asChild?: boolean;
@@ -57,13 +49,11 @@ declare module "@/components/studio/export-dialog" {
   }
 }
 
-// 2. Tambahkan props custom ke Wastra3DViewer
 declare module "@/components/studio/wastra-3d-viewer" {
   export interface Wastra3DViewerProps {
-    isMenuMode?: boolean; // isMenuMode digunakan untuk memicu tampilan ikon
+    isMenuMode?: boolean;
   }
 }
-// =========================================================
 
 type Candidate = {
   imageUrl: string;
@@ -77,7 +67,6 @@ type ExportProgressStatus =
   | "success"
   | "error";
 
-// FIX: Definisikan tipe handler baru untuk mengatasi TS error (dari sesi sebelumnya)
 type StudioSettingsKey = keyof EditorSettings | "mode";
 type StudioSettingsHandler = <K extends StudioSettingsKey>(
   key: K,
@@ -96,7 +85,6 @@ type RightPanelProps = {
   handleSettingsChange: StudioSettingsHandler;
 };
 
-// FIX: Komponen RightPanelContent dipertahankan untuk layout responsif
 const RightPanelContent = ({
   activeTab,
   setActiveTab,
@@ -518,7 +506,7 @@ export default function StudioPage() {
               <div className="w-full max-w-3xl">
                 <div className="aspect-square rounded-2xl border-2 border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 shadow-xl overflow-hidden relative">
                   {selectedCandidate ? (
-                    <div className="w-full h-full relative group">
+                    <div className="w-full h-full relative grouppm">
                       <div className="absolute top-4 right-4 z-20 transition-opacity duration-200">
                         <Button
                           onClick={clearSelection}
@@ -606,33 +594,31 @@ export default function StudioPage() {
         </div>
       </div>
 
-      {/* STICKY FOOTER - FIX: Tempat baru untuk Preview & History di Mobile */}
       {selectedCandidate && (
-        <div className="fixed bottom-0 left-0 right-0 z-50 lg:hidden bg-white/95 dark:bg-zinc-950/95 backdrop-blur-sm border-t border-zinc-200 dark:border-zinc-800 p-3 shadow-2xl">
-          <div className="flex justify-center items-center gap-6 max-w-md mx-auto">
-            {/* 1. Wastra 3D Viewer (Preview) - Icon Only */}
-            <Tooltip>
-              <TooltipTrigger asChild>
+        <div className="fixed bottom-0 left-0 right-0 z-50 lg:hidden bg-white/95 dark:bg-zinc-950/95 backdrop-blur-sm border-t border-zinc-200 dark:border-zinc-800 shadow-2xl">
+          <div className="px-4 py-3">
+            {selectedCandidate ? (
+              <div className="flex items-center justify-center gap-3 max-w-sm mx-auto">
                 <Wastra3DViewer
                   imageUrl={selectedCandidate.imageUrl}
-                  disabled={!selectedCandidate}
-                  isMenuMode={true} // Forces icon-only appearance (isMenuMode is fixed)
+                  disabled={false}
+                  isMenuMode={true}
                 />
-              </TooltipTrigger>
-              <TooltipContent>Tampilan 3D Wastra</TooltipContent>
-            </Tooltip>
 
-            {/* 2. Export History (Riwayat) - FIX: Tombol dengan teks compact */}
-            <ExportHistory asChild={true}>
-              <Button variant="outline" className="h-10 px-4 gap-2">
-                <History className="w-4 h-4" />
-                Riwayat
-              </Button>
-            </ExportHistory>
+                <ExportHistory variant="outline" size="sm" showBadge={true} />
+              </div>
+            ) : (
+              <div className="flex items-center justify-center max-w-sm mx-auto">
+                <ExportHistory
+                  variant="outline"
+                  size="default"
+                  showBadge={true}
+                ></ExportHistory>
+              </div>
+            )}
           </div>
         </div>
       )}
-      {/* END STICKY FOOTER */}
     </TooltipProvider>
   );
 }

--- a/src/components/studio/export-history.tsx
+++ b/src/components/studio/export-history.tsx
@@ -1,5 +1,3 @@
-// src/components/studio/export-history.tsx
-
 "use client";
 
 import React, { useState, useEffect } from "react";
@@ -44,11 +42,20 @@ import {
 type FilterType = "all" | "success" | "failed";
 
 interface ExportHistoryProps {
-  asChild?: boolean;
+  variant?: "default" | "outline" | "ghost";
+  size?: "default" | "sm" | "lg";
+  showBadge?: boolean;
   children?: React.ReactNode;
+  asChild?: boolean;
 }
 
-export function ExportHistory({ asChild, children }: ExportHistoryProps) {
+export function ExportHistory({
+  variant = "outline",
+  size = "sm",
+  showBadge = true,
+  children,
+  asChild = false,
+}: ExportHistoryProps) {
   const [open, setOpen] = useState(false);
   const [history, setHistory] = useState<ExportHistoryItem[]>([]);
   const [filter, setFilter] = useState<FilterType>("all");
@@ -72,7 +79,7 @@ export function ExportHistory({ asChild, children }: ExportHistoryProps) {
   };
 
   const handleClearAll = () => {
-    if (confirm("Yakin ingin menghapus semua riwayat ekspor?")) {
+    if (window.confirm("Yakin ingin menghapus semua riwayat ekspor?")) {
       exportHistory.clear();
       loadHistory();
       toast.success("Semua riwayat dihapus");
@@ -110,202 +117,240 @@ export function ExportHistory({ asChild, children }: ExportHistoryProps) {
   ).length;
   const failedCount = history.filter((item) => item.status === "failed").length;
 
-  // Konten tombol trigger default
-  const defaultTrigger = (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2 h-10 px-4">
-          <History className="w-4 h-4" />
-          Riwayat
-          {history.length > 0 && (
-            <Badge variant="secondary" className="ml-1 px-1.5 py-0 text-xs">
-              {history.length}
-            </Badge>
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>Riwayat Ekspor</TooltipContent>
-    </Tooltip>
-  );
+  // ✅ Render custom trigger jika asChild=true dan children tersedia
+  const triggerButton =
+    asChild && children ? (
+      children
+    ) : (
+      <Button
+        variant={variant}
+        size={size}
+        className="gap-2 h-10 px-3 sm:px-4"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <History className="w-4 h-4" />
+        <span className="hidden sm:inline">Riwayat</span>
+        {showBadge && history.length > 0 && (
+          <Badge
+            variant="secondary"
+            className="ml-1 px-1.5 py-0 text-xs hidden sm:inline-flex"
+          >
+            {history.length}
+          </Badge>
+        )}
+      </Button>
+    );
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        {/* Menggunakan conditional rendering. Jika asChild true, gunakan children (tombol kustom dari page.tsx) */}
-        {asChild ? children : defaultTrigger}
-      </DialogTrigger>
-      {/* FIX: Tambahkan padding horizontal yang aman di DialogContent (p-4 di mobile) */}
-      {/* Catatan: Di Shadcn/UI, p-4 (1rem) sering digunakan sebagai padding default. */}
-      <DialogContent className="max-w-2xl max-h-[80vh] p-4 sm:p-6 flex flex-col">
-        <DialogHeader className="px-0">
-          {" "}
-          {/* FIX: Hilangkan padding di header karena sudah ada di DialogContent */}
-          <DialogTitle>Riwayat Ekspor</DialogTitle>
-          <DialogDescription>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>{triggerButton}</DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>Lihat Riwayat Ekspor</p>
+        </TooltipContent>
+      </Tooltip>
+
+      <DialogContent className="max-w-2xl max-h-[85vh] sm:max-h-[80vh] p-0 gap-0 flex flex-col">
+        {/* Header */}
+        <DialogHeader className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4 border-b">
+          <DialogTitle className="text-xl">Riwayat Ekspor</DialogTitle>
+          <DialogDescription className="text-sm">
             Daftar ekspor yang pernah Anda lakukan. Maksimal 20 riwayat
             terakhir.
           </DialogDescription>
         </DialogHeader>
 
-        {history.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <History className="w-12 h-12 text-zinc-300 dark:text-zinc-700 mb-4" />
-            <p className="text-zinc-500 dark:text-zinc-400">
-              Belum ada riwayat ekspor
-            </p>
-            <p className="text-sm text-zinc-400 dark:text-zinc-600 mt-1">
-              Ekspor desain Anda untuk melihat riwayat di sini
-            </p>
-          </div>
-        ) : (
-          <>
-            {/* Filter & Stats */}
-            <div className="flex items-center justify-between gap-4 pb-2">
-              <div className="flex items-center gap-2">
-                <Filter className="w-4 h-4 text-zinc-500" />
-                <Select
-                  value={filter}
-                  onValueChange={(value) => setFilter(value as FilterType)}
+        {/* Content Area */}
+        <div className="flex-1 overflow-hidden px-4 sm:px-6 py-4">
+          {history.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <div className="w-16 h-16 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center mb-4">
+                <History className="w-8 h-8 text-zinc-400 dark:text-zinc-600" />
+              </div>
+              <p className="text-base font-medium text-zinc-900 dark:text-zinc-100 mb-1">
+                Belum ada riwayat ekspor
+              </p>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                Ekspor desain Anda untuk melihat riwayat di sini
+              </p>
+            </div>
+          ) : (
+            <>
+              {/* Filter & Stats */}
+              <div className="flex items-center justify-between gap-4 mb-4">
+                <div className="flex items-center gap-2">
+                  <Filter className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+                  <Select
+                    value={filter}
+                    onValueChange={(value) => setFilter(value as FilterType)}
+                  >
+                    <SelectTrigger className="h-9 w-[140px] sm:w-[160px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">
+                        Semua ({history.length})
+                      </SelectItem>
+                      <SelectItem value="success">
+                        Berhasil ({successCount})
+                      </SelectItem>
+                      <SelectItem value="failed">
+                        Gagal ({failedCount})
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClearAll}
+                  className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 h-9 text-xs sm:text-sm"
                 >
-                  <SelectTrigger className="h-8 w-[160px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">
-                      Semua ({history.length})
-                    </SelectItem>
-                    <SelectItem value="success">
-                      Berhasil ({successCount})
-                    </SelectItem>
-                    <SelectItem value="failed">
-                      Gagal ({failedCount})
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
+                  <Trash2 className="w-4 h-4 mr-1 sm:mr-2" />
+                  <span className="hidden sm:inline">Hapus Semua</span>
+                  <span className="sm:hidden">Hapus</span>
+                </Button>
               </div>
 
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleClearAll}
-                className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 h-8"
-              >
-                <Trash2 className="w-4 h-4 mr-2" />
-                Hapus Semua
-              </Button>
-            </div>
-
-            <ScrollArea className="h-[500px] pr-4">
-              {filteredHistory.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <Filter className="w-12 h-12 text-zinc-300 dark:text-zinc-700 mb-4" />
-                  <p className="text-zinc-500 dark:text-zinc-400">
-                    Tidak ada riwayat dengan filter ini
-                  </p>
-                </div>
-              ) : (
-                <div className="space-y-3">
-                  {filteredHistory.map((item) => (
-                    <div
-                      key={item.id}
-                      className="border rounded-lg p-3 hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
-                    >
-                      <div className="flex gap-3">
-                        {/* Thumbnail */}
-                        <div className="relative w-16 h-16 rounded overflow-hidden bg-zinc-100 dark:bg-zinc-800 flex-shrink-0">
-                          {item.imageUrl ? (
-                            <Image
-                              src={item.imageUrl}
-                              alt="Thumbnail"
-                              fill
-                              className="object-cover"
-                              unoptimized
-                            />
-                          ) : (
-                            <div className="w-full h-full flex items-center justify-center">
-                              <XCircle className="w-6 h-6 text-zinc-400" />
-                            </div>
-                          )}
-                        </div>
-
-                        {/* Info */}
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-start justify-between gap-2">
-                            <div className="flex-1 min-w-0">
-                              <h4 className="font-medium text-sm truncate">
-                                {item.fileName}
-                              </h4>
-                              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
-                                {formatDistanceToNow(new Date(item.timestamp), {
-                                  addSuffix: true,
-                                  locale: idLocale,
-                                })}
-                              </p>
-                            </div>
-                            {item.status === "success" ? (
-                              <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
+              {/* History List */}
+              <ScrollArea className="h-[calc(85vh-240px)] sm:h-[calc(80vh-240px)] pr-2 sm:pr-4">
+                {filteredHistory.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center">
+                    <div className="w-16 h-16 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center mb-4">
+                      <Filter className="w-8 h-8 text-zinc-400 dark:text-zinc-600" />
+                    </div>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                      Tidak ada riwayat dengan filter ini
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-3 pb-2">
+                    {filteredHistory.map((item) => (
+                      <div
+                        key={item.id}
+                        className="border border-zinc-200 dark:border-zinc-800 rounded-lg p-3 hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
+                      >
+                        <div className="flex gap-3">
+                          {/* Thumbnail */}
+                          <div className="relative w-14 h-14 sm:w-16 sm:h-16 rounded-lg overflow-hidden bg-zinc-100 dark:bg-zinc-800 flex-shrink-0">
+                            {item.imageUrl ? (
+                              <Image
+                                src={item.imageUrl}
+                                alt="Thumbnail"
+                                fill
+                                className="object-cover"
+                                unoptimized
+                              />
                             ) : (
-                              <XCircle className="w-4 h-4 text-red-600 flex-shrink-0" />
+                              <div className="w-full h-full flex items-center justify-center">
+                                <XCircle className="w-6 h-6 text-zinc-400" />
+                              </div>
                             )}
                           </div>
 
-                          {/* Metadata */}
-                          <div className="flex flex-wrap gap-2 mt-2">
-                            <Badge variant="outline" className="text-xs">
-                              {item.settings.rapportCm}x
-                              {item.settings.rapportCm} cm
-                            </Badge>
-                            <Badge variant="outline" className="text-xs">
-                              {item.settings.dpi} DPI
-                            </Badge>
-                            <Badge variant="outline" className="text-xs">
-                              {formatFileSize(item.fileSize)}
-                            </Badge>
-                            <Badge
-                              variant="outline"
-                              className="text-xs uppercase"
-                            >
-                              {item.settings.format}
-                            </Badge>
-                          </div>
+                          {/* Info */}
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2 mb-1">
+                              <div className="flex-1 min-w-0">
+                                <h4 className="font-medium text-sm text-zinc-900 dark:text-zinc-100 truncate">
+                                  {item.fileName}
+                                </h4>
+                                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                                  {formatDistanceToNow(
+                                    new Date(item.timestamp),
+                                    {
+                                      addSuffix: true,
+                                      locale: idLocale,
+                                    }
+                                  )}
+                                </p>
+                              </div>
+                              {item.status === "success" ? (
+                                <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
+                              ) : (
+                                <XCircle className="w-4 h-4 text-red-600 flex-shrink-0" />
+                              )}
+                            </div>
 
-                          {/* Actions */}
-                          <div className="flex gap-2 mt-3">
-                            {item.status === "success" && item.downloadUrl && (
+                            {/* Metadata Badges */}
+                            <div className="flex flex-wrap gap-1.5 sm:gap-2 mt-2">
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-1.5 py-0"
+                              >
+                                {item.settings.rapportCm}×
+                                {item.settings.rapportCm} cm
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-1.5 py-0"
+                              >
+                                {item.settings.dpi} DPI
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-1.5 py-0"
+                              >
+                                {formatFileSize(item.fileSize)}
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className="text-[10px] sm:text-xs px-1.5 py-0 uppercase"
+                              >
+                                {item.settings.format}
+                              </Badge>
+                            </div>
+
+                            {/* Action Buttons */}
+                            <div className="flex gap-2 mt-3">
+                              {item.status === "success" &&
+                                item.downloadUrl && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="h-7 text-xs gap-1 px-2 sm:px-3"
+                                    onClick={() => handleRedownload(item)}
+                                  >
+                                    <Download className="w-3 h-3" />
+                                    <span className="hidden sm:inline">
+                                      Unduh Ulang
+                                    </span>
+                                    <span className="sm:hidden">Unduh</span>
+                                  </Button>
+                                )}
                               <Button
                                 size="sm"
-                                variant="outline"
-                                className="h-7 text-xs gap-1"
-                                onClick={() => handleRedownload(item)}
+                                variant="ghost"
+                                className="h-7 text-xs gap-1 px-2 sm:px-3 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
+                                onClick={() => handleDelete(item.id)}
                               >
-                                <Download className="w-3 h-3" />
-                                Unduh Ulang
+                                <Trash2 className="w-3 h-3" />
+                                Hapus
                               </Button>
-                            )}
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-7 text-xs gap-1 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
-                              onClick={() => handleDelete(item.id)}
-                            >
-                              <Trash2 className="w-3 h-3" />
-                              Hapus
-                            </Button>
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </ScrollArea>
-          </>
-        )}
+                    ))}
+                  </div>
+                )}
+              </ScrollArea>
+            </>
+          )}
+        </div>
 
-        <div className="px-0 pt-4 border-t">
-          {" "}
-          {/* FIX: Hilangkan padding horizontal di footer karena sudah ada di DialogContent, tapi pertahankan vertical spacing */}
-          <Button onClick={() => setOpen(false)} className="w-full">
+        {/* Footer */}
+        <div className="px-4 sm:px-6 py-4 border-t">
+          <Button
+            onClick={() => setOpen(false)}
+            className="w-full h-10"
+            variant="default"
+          >
             Tutup
           </Button>
         </div>

--- a/src/components/studio/wastra-3d-viewer.tsx
+++ b/src/components/studio/wastra-3d-viewer.tsx
@@ -20,19 +20,17 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Box, Loader2, Shirt, Layers } from "lucide-react"; // FIX: Tambah X untuk tombol tutup
+import { Box, Loader2, Shirt, Layers } from "lucide-react";
 import * as THREE from "three";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip"; // FIX: Import Tooltip
-import { cn } from "@/lib/utils"; // FIX: Import cn
+} from "@/components/ui/tooltip";
 
-interface Wastra3DViewerProps {
+export interface Wastra3DViewerProps {
   imageUrl: string;
   disabled?: boolean;
-  // FIX: Tambahkan prop untuk kontrol tampilan di menu/footer mobile
   isMenuMode?: boolean;
 }
 
@@ -43,23 +41,18 @@ function ShirtGLBModel({ textureUrl }: { textureUrl: string }) {
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(1, 1);
   texture.flipY = false;
-
-  // Fix texture color space
   texture.colorSpace = THREE.SRGBColorSpace;
 
   useEffect(() => {
     scene.traverse((child: any) => {
       if (child.isMesh) {
-        // Create a new standard material with proper settings
         child.material = new THREE.MeshStandardMaterial({
           map: texture,
-          roughness: 0.85, // Higher = less shiny
-          metalness: 0.0, // Fabric should not be metallic
+          roughness: 0.85,
+          metalness: 0.0,
           side: THREE.FrontSide,
         });
         child.material.needsUpdate = true;
-
-        // Disable receive shadow to reduce lighting effects
         child.receiveShadow = false;
         child.castShadow = false;
       }
@@ -110,7 +103,7 @@ function LoadingFallback() {
 
 export function Wastra3DViewer({
   imageUrl,
-  disabled,
+  disabled = false,
   isMenuMode = false,
 }: Wastra3DViewerProps) {
   const [open, setOpen] = useState(false);
@@ -126,34 +119,47 @@ export function Wastra3DViewer({
     setIsLoading(true);
   };
 
-  // Konten tombol trigger default
-  const defaultTrigger = (
-    <Button
-      variant="outline"
-      size={isMenuMode ? "default" : "sm"}
-      disabled={disabled}
-      className={cn(
-        "gap-2 h-9 px-3 sm:h-10 sm:px-4", // Ukuran default (navbar desktop)
-        isMenuMode && "w-full justify-center h-10 px-4 text-base" // Tampilan penuh di dalam menu/footer mobile (ikon saja)
-      )}
-    >
-      {/* FIX: Menggunakan Box sebagai ikon 3D Preview */}
-      <Box className={cn("w-6 h-6", isMenuMode ? "w-6 h-6" : "w-4 h-4 mr-2")} />
-      {/* Text hanya tampil di desktop navbar atau saat isMenuMode (untuk tombol penuh di menu) */}
-      <span className={cn(isMenuMode ? "hidden lg:inline" : "inline")}>
-        3D Preview
-      </span>
-    </Button>
-  );
+  // FIX: Render berbeda untuk mode icon-only vs full button
+  const renderTrigger = () => {
+    if (isMenuMode) {
+      // Mode Icon Only - untuk mobile footer
+      return (
+        <Button
+          variant="outline"
+          size="icon"
+          disabled={disabled}
+          className="h-10 w-10 flex-shrink-0"
+        >
+          <Box className="w-5 h-5" />
+        </Button>
+      );
+    }
+
+    // Mode Full Button - untuk navbar desktop
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        className="gap-2 h-10 px-3 sm:px-4"
+      >
+        <Box className="w-4 h-4" />
+        <span className="hidden sm:inline">3D Preview</span>
+      </Button>
+    );
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <Tooltip delayDuration={0}>
+      <Tooltip delayDuration={300}>
         <TooltipTrigger asChild>
-          <DialogTrigger asChild>{defaultTrigger}</DialogTrigger>
+          <DialogTrigger asChild>{renderTrigger()}</DialogTrigger>
         </TooltipTrigger>
-        <TooltipContent>Tampilan 3D Wastra</TooltipContent>
+        <TooltipContent side={isMenuMode ? "top" : "bottom"}>
+          <p>Tampilan 3D Wastra</p>
+        </TooltipContent>
       </Tooltip>
+
       <DialogContent className="max-w-4xl h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Wastra 3D Preview</DialogTitle>
@@ -183,13 +189,12 @@ export function Wastra3DViewer({
               gl={{
                 antialias: true,
                 toneMapping: THREE.ACESFilmicToneMapping,
-                toneMappingExposure: 1.0, // Adjust if still too bright
+                toneMappingExposure: 1.0,
               }}
             >
               <Suspense fallback={null}>
                 <PerspectiveCamera makeDefault position={[0, 0, 5]} fov={50} />
 
-                {/* Balanced lighting - not too bright */}
                 <ambientLight intensity={0.5} />
                 <directionalLight
                   position={[3, 3, 3]}
@@ -215,7 +220,6 @@ export function Wastra3DViewer({
                   dampingFactor={0.05}
                 />
 
-                {/* Soft environment lighting */}
                 <Environment preset="apartment" environmentIntensity={0.3} />
               </Suspense>
             </Canvas>
@@ -235,7 +239,6 @@ export function Wastra3DViewer({
               <Suspense fallback={null}>
                 <PerspectiveCamera makeDefault position={[0, 0, 4]} fov={60} />
 
-                {/* Soft lighting for fabric */}
                 <ambientLight intensity={0.6} />
                 <directionalLight
                   position={[2, 2, 2]}


### PR DESCRIPTION
Improves the mobile sticky footer in the studio page by updating the ExportHistory and Wastra3DViewer components to support more flexible props and better UI. ExportHistory now supports variant, size, and showBadge props, and its dialog and list UI have been enhanced for clarity and usability. Wastra3DViewer now provides a more consistent icon-only trigger for mobile and a full button for desktop, with improved tooltip and dialog behavior. Removes unused comments and cleans up module augmentation and type definitions.